### PR TITLE
Adding ingress for elasticsearch endpoints for kn

### DIFF
--- a/deploy/helm/magda-dev-kn-v0.0.41.yml
+++ b/deploy/helm/magda-dev-kn-v0.0.41.yml
@@ -1,6 +1,7 @@
 global:
   useCombinedDb: false
   externalUrl: https://dev.knowledgenet.co
+  externalUrlEs: https://dev-es.knowledgenet.co
   rollingUpdate:
     maxUnavailable: 1
   image:

--- a/deploy/helm/magda-prod-kn-prod-v41.yml
+++ b/deploy/helm/magda-prod-kn-prod-v41.yml
@@ -1,6 +1,7 @@
 global:
   useCombinedDb: false
   externalUrl: knowledgenet.co
+  externalUrlEs: es.knowledgenet.co
   tls-secret: kn-tls-secret
   rollingUpdate:
     maxUnavailable: 1
@@ -18,6 +19,8 @@ tags:
     registry-db: true
     search-api: true
     session-db: true
+    kn-ingress: true
+    kn-es-ingress: true
     web-server: true
 
 gateway:

--- a/deploy/helm/magda/charts/kn-es-ingress/Chart.yaml
+++ b/deploy/helm/magda/charts/kn-es-ingress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: kn-es-ingress
+version: 0.1.0

--- a/deploy/helm/magda/charts/kn-es-ingress/templates/ingress.yaml
+++ b/deploy/helm/magda/charts/kn-es-ingress/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: kn-es-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/server-snippet: |
+       add_header Allow "GET, POST, HEAD" always;
+        if ( $request_method !~ ^(GET|POST|HEAD|OPTIONS)$ ) {
+            return 405;
+        }
+        location ~ ^/(datasets30|regions17)/(?!_search) {
+           return 405;
+        }
+        location ~ ^/_cat/(?!indices) {
+           return 405;
+        }
+spec:
+  rules:
+    - host: {{ .Values.global.externalUrlEs }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: elasticsearch
+            servicePort: 9200
+  tls:
+   - secretName: {{ .Values.global.tls-secret }}
+     hosts:
+     - {{ .Values.global.externalUrlEs }}

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -35,3 +35,4 @@ tags:
   web-server: false
   kn-web-app: false
   dev-ingress: false
+  kn-es-ingress: false


### PR DESCRIPTION
This adds ingress for elasticsearch endpoints to the main helm deployment. This was previously manually done, but these changes attempts to make them as part of the helm deployment. Suggested helm configs also included for dev and prod